### PR TITLE
Feature/flag rate limit

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -70,12 +70,11 @@ func DownloadFile(url string, opts Options, log *logger.Logger) error {
 		for {
 			n, readErr := resp.Body.Read(buf)
 			if n > 0 {
-				// Rate limiting logic
 				if opts.RateLimit > 0 {
 					now := time.Now()
 					if !lastReadTime.IsZero() {
 						elapsed := now.Sub(lastReadTime)
-						expected := time.Duration(float64(n) / opts.RateLimit * 1e9) // bytes per second to nanoseconds
+						expected := time.Duration(float64(n) / opts.RateLimit * 1e9)
 						if expected > elapsed {
 							time.Sleep(expected - elapsed)
 						}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -67,9 +68,8 @@ func (l *Logger) Progress(written, total int64, speed float64, eta time.Duration
 	remainingBars := barWidth - doneBars
 
 	speedStr := util.FormatSpeed(speed)
-
-	fmt.Fprintf(l.Output,
-		"\r%.2f KiB / %.2f KiB [%s%s] %6.2f%% %s %s",
+	progressLine := fmt.Sprintf(
+		"%.2f KiB / %.2f KiB [%s%s] %6.2f%% %s %s",
 		writtenKiB,
 		totalKiB,
 		strings.Repeat("=", doneBars),
@@ -78,8 +78,17 @@ func (l *Logger) Progress(written, total int64, speed float64, eta time.Duration
 		speedStr,
 		util.FormatETA(eta),
 	)
-	if written == total {
-		fmt.Fprintln(l.Output)
+
+	// Determine if we should overwrite or write new lines
+	if l.Output == os.Stdout {
+		// Overwrite previous line in terminal
+		fmt.Fprintf(l.Output, "\r%s", progressLine)
+		if written == total {
+			fmt.Fprintln(l.Output) // Final newline after complete
+		}
+	} else {
+		// Append new line in file log
+		fmt.Fprintln(l.Output, progressLine)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/jesee-kuya/wget/downloader"
 	"github.com/jesee-kuya/wget/logger"
+	"github.com/jesee-kuya/wget/util"
 )
 
 func main() {
 	background := flag.Bool("B", false, "Download in background and log output to wget-log")
 	output := flag.String("O", "", "Specify file name")
-	outputDir := flag.String("P", "", "Specify directory to save the file")	
+	outputDir := flag.String("P", "", "Specify directory to save the file")
+	rateLimit := flag.String("rate-limit", "", "Limit download speed (e.g., 100k, 1M)")
+
 	flag.Parse()
 	args := flag.Args()
 
@@ -23,9 +26,16 @@ func main() {
 
 	url := args[0]
 
+	parsedRate, err := util.ParseRateLimit(*rateLimit)
+	if err != nil {
+		fmt.Println("Error parsing rate limit:", err)
+		return
+	}
+
 	opts := downloader.Options{
 		OutputName: *output,
 		OutputDir:  *outputDir,
+		RateLimit:  parsedRate,
 	}
 
 	if *background {
@@ -51,7 +61,7 @@ func main() {
 
 	log := logger.NewLogger(os.Stdout)
 
-	err := downloader.DownloadFile(url, opts, log)
+	err = downloader.DownloadFile(url, opts, log)
 	if err != nil {
 		log.Error(err)
 		return

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/jesee-kuya/wget/downloader"
 	"github.com/jesee-kuya/wget/logger"
@@ -41,7 +42,40 @@ func main() {
 	if *background {
 		fmt.Println("Output will be written to \"wget-log\".")
 
-		logFile, err := os.Create("wget-log")
+		// If already running in background, skip re-exec
+		if os.Getenv("WGET_BACKGROUND") != "1" {
+			// Re-exec the same binary in background
+			execPath, err := os.Executable()
+			if err != nil {
+				fmt.Println("Error finding executable path:", err)
+				return
+			}
+
+			cmd := exec.Command(execPath, os.Args[1:]...)
+			cmd.Env = append(os.Environ(), "WGET_BACKGROUND=1")
+
+			// Redirect output to log file
+			logFile, err := os.OpenFile("wget-log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+			if err != nil {
+				fmt.Println("Error creating log file:", err)
+				return
+			}
+			defer logFile.Close()
+
+			cmd.Stdout = logFile
+			cmd.Stderr = logFile
+			cmd.Stdin = nil // disconnect input
+
+			// Start the process and exit the parent
+			if err := cmd.Start(); err != nil {
+				fmt.Println("Failed to start background process:", err)
+				return
+			}
+			return
+		}
+
+		// Actual background logic starts here
+		logFile, err := os.OpenFile("wget-log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err != nil {
 			fmt.Println("Error creating log file:", err)
 			return
@@ -50,7 +84,6 @@ func main() {
 
 		fileLogger := logger.NewLogger(logFile)
 
-		// Perform the download using our downloader
 		err = downloader.DownloadFile(url, opts, fileLogger)
 		if err != nil {
 			fmt.Fprintf(logFile, "Download failed: %v\n", err)

--- a/util/ratelimit.go
+++ b/util/ratelimit.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func ParseRateLimit(rate string) (float64, error) {
+	if rate == "" {
+		return 0, nil
+	}
+
+	multiplier := 1.0
+	unit := strings.ToLower(rate[len(rate)-1:])
+
+	switch unit {
+	case "k":
+		multiplier = 1024.0
+		rate = rate[:len(rate)-1]
+	case "m":
+		multiplier = 1024.0 * 1024.0
+		rate = rate[:len(rate)-1]
+	case "g":
+		multiplier = 1024.0 * 1024.0 * 1024.0
+		rate = rate[:len(rate)-1]
+	default:
+		return 0, fmt.Errorf("invalid rate limit unit: %s", unit)
+
+	}
+
+	value, err := strconv.ParseFloat(rate, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse rate limit: %w", err)
+	}
+
+	return value * multiplier, nil
+}


### PR DESCRIPTION
## Summary

This pull request adds support for the `--rate-limit` flag, allowing users to control the download speed of files. The rate limit is defined in bytes per second and helps users avoid saturating their internet bandwidth when downloading large files.

## Features

- Updated the `DownloadFile` function to:
  - Enforce rate-limited reads from the HTTP response body.
  - Use a `time.Sleep()` based throttling mechanism.
  - Calculate expected read duration based on actual bytes read and target rate.

## Example Usage

```bash
$ go run . --rate-limit=400k https://example.com/largefile.zip
```

Closes #21
