### PR TITLE
feat: improve progress logging for unknown total size in Logger

### DIFF
--- a/downloader/mirror.go
+++ b/downloader/mirror.go
@@ -21,7 +21,6 @@ import (
 // All files are saved under a folder named after the domain (e.g., "www.example.com").
 // It uses parser.ExtractLinks to find internal <a>, <link>, and <img> references.
 func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
-	// Parse the starting URL
 	base, err := url.Parse(startURL)
 	if err != nil {
 		return fmt.Errorf("invalid start URL %q: %w", startURL, err)
@@ -30,12 +29,10 @@ func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
 	visited := make(map[string]bool)
 	var mu sync.Mutex
 
-	// queueSlice implements a simple FIFO queue
 	queueSlice := []string{startURL}
 	visited[startURL] = true
 
 	for len(queueSlice) > 0 {
-		// Pop front
 		mu.Lock()
 		currentURL := queueSlice[0]
 		queueSlice = queueSlice[1:]
@@ -51,7 +48,6 @@ func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
 			continue
 		}
 
-		// Download the current URL
 		log.Start(currentURL, time.Now())
 		resp, err := http.Get(currentURL)
 		if err != nil {
@@ -65,7 +61,6 @@ func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
 			continue
 		}
 
-		// Determine where to save this file in the domain directory
 		saveDir, err := util.CreateURLDirectories(currentURL, opts.OutputDir)
 		if err != nil {
 			log.Error(fmt.Errorf("failed to create folders for %s: %w", currentURL, err))
@@ -73,12 +68,10 @@ func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
 			continue
 		}
 
-		// Derive the filename from the URL path
 		filename := util.ExtractFilenameFromURL(currentURL)
 		outputPath := filepath.Join(saveDir, filename)
 		log.SavingTo(outputPath)
 
-		// Read the entire response body into memory (so we can both save and parse it if HTML)
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if readErr != nil {
@@ -86,7 +79,6 @@ func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
 			continue
 		}
 
-		// Write the body to a file
 		fileErr := os.WriteFile(outputPath, bodyBytes, 0o644)
 		if fileErr != nil {
 			log.Error(fmt.Errorf("failed to write file %s: %w", outputPath, fileErr))
@@ -96,20 +88,16 @@ func MirrorSite(startURL string, opts Options, log *logger.Logger) error {
 		log.Progress(int64(len(bodyBytes)), int64(len(bodyBytes)), 0, 0)
 		log.Done(time.Now(), currentURL)
 
-		// If content-type is HTML, parse for additional links
 		contentType := resp.Header.Get("Content-Type")
 		if strings.HasPrefix(contentType, "text/html") {
-			// Create a reader over the saved body bytes
 			reader := bytes.NewReader(bodyBytes)
 
-			// Extract internal links
 			foundLinks, parseErr := parser.ExtractLinks(base, reader)
 			if parseErr != nil {
 				log.Error(fmt.Errorf("failed to parse HTML %s: %w", currentURL, parseErr))
 				continue
 			}
 
-			// Enqueue each new link
 			for _, link := range foundLinks {
 				mu.Lock()
 				if !visited[link] {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,7 +29,7 @@ func (l *Logger) Done(timestamp time.Time, url string) {
 // Start logs the start of a process with a timestamp.
 func (l *Logger) Start(url string, timestamp time.Time) {
 	fmt.Fprintf(l.Output, "start at %s\n", timestamp.Format("2006-01-02 15:04:05"))
-	fmt.Fprintf(l.Output, "sending request, awaiting response... ")
+	//fmt.Fprintf(l.Output, "sending request, awaiting response... ")
 }
 
 // SavingTo logs the path where the file is being saved.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -58,16 +58,44 @@ func (l *Logger) Progress(written, total int64, speed float64, eta time.Duration
 
 	toKiB := func(b int64) float64 { return float64(b) / 1024.0 }
 	writtenKiB := toKiB(written)
-	totalKiB := toKiB(total)
+	speedStr := util.FormatSpeed(speed)
 
-	percent := float64(written) / float64(total)
-	if total == 0 {
-		percent = 0
+	if total <= 0 {
+		progressIndex := int(written/10240) % barWidth
+		bar := make([]rune, barWidth)
+		for i := range bar {
+			if i == progressIndex {
+				bar[i] = '>'
+			} else {
+				bar[i] = ' '
+			}
+		}
+		progressLine := fmt.Sprintf(
+			"%.2f KiB / ??.?? KiB [%s]   ??%% %s ETA: ?",
+			writtenKiB,
+			string(bar),
+			speedStr,
+		)
+
+		if l.Output == os.Stdout {
+			fmt.Fprintf(l.Output, "\r%s", progressLine)
+		} else {
+			fmt.Fprintln(l.Output, progressLine)
+		}
+		return
 	}
+
+	totalKiB := toKiB(total)
+	percent := float64(written) / float64(total)
 	doneBars := int(percent * float64(barWidth))
+	if doneBars > barWidth {
+		doneBars = barWidth
+	}
+	if doneBars < 0 {
+		doneBars = 0
+	}
 	remainingBars := barWidth - doneBars
 
-	speedStr := util.FormatSpeed(speed)
 	progressLine := fmt.Sprintf(
 		"%.2f KiB / %.2f KiB [%s%s] %6.2f%% %s %s",
 		writtenKiB,
@@ -79,15 +107,12 @@ func (l *Logger) Progress(written, total int64, speed float64, eta time.Duration
 		util.FormatETA(eta),
 	)
 
-	// Determine if we should overwrite or write new lines
 	if l.Output == os.Stdout {
-		// Overwrite previous line in terminal
 		fmt.Fprintf(l.Output, "\r%s", progressLine)
 		if written == total {
-			fmt.Fprintln(l.Output) // Final newline after complete
+			fmt.Fprintln(l.Output)
 		}
 	} else {
-		// Append new line in file log
 		fmt.Fprintln(l.Output, progressLine)
 	}
 }


### PR DESCRIPTION
###Summary

This PR fixes a critical issue where the progress bar logic would panic when downloading files with unknown Content-Length headers (e.g., when servers omit the Content-Length header).